### PR TITLE
[improve][client]check ClientConfigurationData is valid in advance

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -202,6 +202,10 @@ public class PulsarClientImpl implements PulsarClient {
         EventLoopGroup eventLoopGroupReference = null;
         ConnectionPool connectionPoolReference = null;
         try {
+            if (conf == null || isBlank(conf.getServiceUrl())) {
+                throw new PulsarClientException.InvalidConfigurationException("Invalid client configuration");
+            }
+            this.conf = conf;
             this.createdEventLoopGroup = eventLoopGroup == null;
             this.createdCnxPool = connectionPool == null;
             if ((externalExecutorProvider == null) != (internalExecutorProvider == null)) {
@@ -213,10 +217,6 @@ public class PulsarClientImpl implements PulsarClient {
             this.createdLookupProviders = lookupExecutorProvider == null;
             eventLoopGroupReference = eventLoopGroup != null ? eventLoopGroup : getEventLoopGroup(conf);
             this.eventLoopGroup = eventLoopGroupReference;
-            if (conf == null || isBlank(conf.getServiceUrl())) {
-                throw new PulsarClientException.InvalidConfigurationException("Invalid client configuration");
-            }
-            this.conf = conf;
             this.instrumentProvider = new InstrumentProvider(conf.getOpenTelemetry());
             clientClock = conf.getClock();
             conf.getAuthentication().start();


### PR DESCRIPTION
### Motivation
when conf is invalid, the previous operations before check conf is all unnessarily and waste system resources and will bring NPE as code below.
```
eventLoopGroupReference = eventLoopGroup != null ? eventLoopGroup : getEventLoopGroup(conf);
```

**so we need to check conf in the begining**


### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
