### PR TITLE
[fix][test] fix flaky EntryCacheManagerTest.simple

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/EntryCacheManagerTest.java
@@ -105,10 +105,9 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
 
         cache2.insert(EntryImpl.create(2, 0, new byte[1]));
         cache2.insert(EntryImpl.create(2, 1, new byte[1]));
-        cache2.insert(EntryImpl.create(2, 2, new byte[1]));
 
-        assertEquals(cache2.getSize(), 3);
-        assertEquals(cacheManager.getSize(), 10);
+        assertEquals(cache2.getSize(), 2);
+        assertEquals(cacheManager.getSize(), 9);
 
         // Next insert should trigger a cache eviction to force the size to 8
         // The algorithm should evict entries from cache1
@@ -116,29 +115,29 @@ public class EntryCacheManagerTest extends MockedBookKeeperTestCase {
 
         factory2.waitForPendingCacheEvictions();
 
-        assertEquals(cacheManager.getSize(), 7);
+        assertEquals(cacheManager.getSize(), 6);
         assertEquals(cache1.getSize(), 3);
-        assertEquals(cache2.getSize(), 4);
+        assertEquals(cache2.getSize(), 3);
 
         cacheManager.removeEntryCache("cache1");
-        assertEquals(cacheManager.getSize(), 4);
-        assertEquals(cache2.getSize(), 4);
+        assertEquals(cacheManager.getSize(), 3);
+        assertEquals(cache2.getSize(), 3);
 
         // Should remove 1 entry
         cache2.invalidateEntries(PositionFactory.create(2, 1));
-        assertEquals(cacheManager.getSize(), 3);
-        assertEquals(cache2.getSize(), 3);
+        assertEquals(cacheManager.getSize(), 2);
+        assertEquals(cache2.getSize(), 2);
 
         factory2.getMbean().refreshStats(1, TimeUnit.SECONDS);
 
         assertEquals(factory2.getMbean().getCacheMaxSize(), 10);
-        assertEquals(factory2.getMbean().getCacheUsedSize(), 3);
+        assertEquals(factory2.getMbean().getCacheUsedSize(), 2);
         assertEquals(factory2.getMbean().getCacheHitsRate(), 0.0);
         assertEquals(factory2.getMbean().getCacheMissesRate(), 0.0);
         assertEquals(factory2.getMbean().getCacheHitsThroughput(), 0.0);
         assertEquals(factory2.getMbean().getNumberOfCacheEvictions(), 1);
-        assertEquals(factory2.getMbean().getCacheInsertedEntriesCount(), 6);
-        assertEquals(factory2.getMbean().getCacheEntriesCount(), 3);
+        assertEquals(factory2.getMbean().getCacheInsertedEntriesCount(), 5);
+        assertEquals(factory2.getMbean().getCacheEntriesCount(), 2);
         assertEquals(factory2.getMbean().getCacheEvictedEntriesCount(), 3);
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24608
### motivation
this test was flaky due to
**line108** in ```EntryCacheManagerTest.java``` of current master branch
already triggered cache eviction, so sometimes the eviction is over, sometimes not, cause this flaky.

### Modifications
1. Removed one entry insertion (`EntryImpl.create(2, 2, new byte[1]`) to:
   - Ensure predictable cache eviction timing
   - Maintain test's original purpose of verifying eviction logic
2. Updated all affected assertions to match the new expected cache sizes:
   - Reduced expected sizes by 1 across all assertions
   - Maintained consistent state validation throughout test flow
### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
