### PR TITLE
[fix][test]fix flaky SimpleProducerConsumerTest.testReceiveAsyncCompletedWhenClosing

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4032,17 +4032,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // 1) Test receiveAsync is interrupted
         CountDownLatch countDownLatch = new CountDownLatch(1);
         new Thread(() -> {
-            CountDownLatch subCoundDownLatch = new CountDownLatch(1);
+            CountDownLatch subCountDownLatch = new CountDownLatch(1);
             try {
                 new Thread(() -> {
                     try {
-                        subCoundDownLatch.await();
+                        subCountDownLatch.await();
                         consumer.close();
                     } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
                 CompletableFuture<Message<String>> futhre = consumer.receiveAsync();
-                subCoundDownLatch.countDown();
+                subCountDownLatch.countDown();
                 futhre.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {
@@ -4060,16 +4060,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 .batchReceivePolicy(batchReceivePolicy).subscribe();
         new Thread(() -> {
             try {
-                CountDownLatch subCoundDownLatch = new CountDownLatch(1);
+                CountDownLatch subCountDownLatch = new CountDownLatch(1);
                 new Thread(() -> {
                     try {
-                        subCoundDownLatch.await();
+                        subCountDownLatch.await();
                         consumer2.close();
                     } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
                 CompletableFuture<Messages<String>> future = consumer2.batchReceiveAsync();
-                subCoundDownLatch.countDown();
+                subCountDownLatch.countDown();
                 future.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {
@@ -4087,17 +4087,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 .batchReceivePolicy(batchReceivePolicy).subscribe();
         new Thread(() -> {
             try {
-                CountDownLatch subCoundDownLatch = new CountDownLatch(1);
+                CountDownLatch subCountDownLatch = new CountDownLatch(1);
                 new Thread(() -> {
                     try {
-                        subCoundDownLatch.await();
+                        subCountDownLatch.await();
                         partitionedTopicConsumer.close();
                     } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
                 CompletableFuture<Messages<String>> future =
                         partitionedTopicConsumer.batchReceiveAsync();
-                subCoundDownLatch.countDown();
+                subCountDownLatch.countDown();
                 future.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -4032,14 +4032,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // 1) Test receiveAsync is interrupted
         CountDownLatch countDownLatch = new CountDownLatch(1);
         new Thread(() -> {
+            CountDownLatch subCoundDownLatch = new CountDownLatch(1);
             try {
                 new Thread(() -> {
                     try {
+                        subCoundDownLatch.await();
                         consumer.close();
-                    } catch (PulsarClientException ignore) {
+                    } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
-                consumer.receiveAsync().get();
+                CompletableFuture<Message<String>> futhre = consumer.receiveAsync();
+                subCoundDownLatch.countDown();
+                futhre.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {
                 Assert.assertTrue(e.getMessage().contains(errorMsg));
@@ -4056,13 +4060,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 .batchReceivePolicy(batchReceivePolicy).subscribe();
         new Thread(() -> {
             try {
+                CountDownLatch subCoundDownLatch = new CountDownLatch(1);
                 new Thread(() -> {
                     try {
+                        subCoundDownLatch.await();
                         consumer2.close();
-                    } catch (PulsarClientException ignore) {
+                    } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
-                consumer2.batchReceiveAsync().get();
+                CompletableFuture<Messages<String>> future = consumer2.batchReceiveAsync();
+                subCoundDownLatch.countDown();
+                future.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {
                 Assert.assertTrue(e.getMessage().contains(errorMsg));
@@ -4079,13 +4087,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 .batchReceivePolicy(batchReceivePolicy).subscribe();
         new Thread(() -> {
             try {
+                CountDownLatch subCoundDownLatch = new CountDownLatch(1);
                 new Thread(() -> {
                     try {
+                        subCoundDownLatch.await();
                         partitionedTopicConsumer.close();
-                    } catch (PulsarClientException ignore) {
+                    } catch (PulsarClientException | InterruptedException ignore) {
                     }
                 }).start();
-                partitionedTopicConsumer.batchReceiveAsync().get();
+                CompletableFuture<Messages<String>> future =
+                        partitionedTopicConsumer.batchReceiveAsync();
+                subCoundDownLatch.countDown();
+                future.get();
                 Assert.fail("should be interrupted");
             } catch (Exception e) {
                 Assert.assertTrue(e.getMessage().contains(errorMsg));


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24850

### Motivation
The test ```testReceiveAsyncCompletedWhenClosing``` was experiencing concurrency race conditions that caused flaky test failures. The issue occurred due to unpredictable timing between two operations:

- ```consumer.receiveAsync()``` or ```batchReceiveAsync()```

- ```consumer.close()```

#### Expected behavior:
- receiveAsync() should happen before close(), allowing the async operation to be properly interrupted by the close.

#### Flaky scenario:
- When ```close()``` executes before receiveAsync(), the subsequent ```receiveAsync()``` call immediately returns a ```CompletableFuture``` that completes with a ```PulsarClientException``` containing the message **"Consumer already closed"**. This differs from the expected interruption behavior and causes the test assertion to fail.
### Modifications
ensure ```consumer.receiveAsync()```  happens before ```consumer.close()```
#### Solution
Added proper synchronization using CountDownLatch to ensure:

- The async operation (receiveAsync/batchReceiveAsync) starts first

- The close() operation executes only after the async operation has begun
### Verifying this change

- [x] Make sure that the change passes the CI checks.

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
