### PR TITLE
[fix][broker] Fix totalAvailablePermits not reduced when removing consumer from non-persistent dispatcher

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -105,6 +105,8 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
                     closeFuture.complete(null);
                 }
                 TOTAL_AVAILABLE_PERMITS_UPDATER.set(this, 0);
+            } else {
+                TOTAL_AVAILABLE_PERMITS_UPDATER.addAndGet(this, -consumer.getAvailablePermits());
             }
         } else {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation
When ```NonPersistentDispatcherMultipleConsumers``` removes a consumer via the ```removeConsumer()``` method, the ```TOTAL_AVAILABLE_PERMITS_UPDATER``` is not properly decremented when there are multiple consumers (consumers' size > 1). This creates an inconsistency where the dispatcher maintains an inflated count of available permits after consumer removal

### Modifications

- Added logic in ```NonPersistentDispatcherMultipleConsumers.removeConsumer()``` to properly decrement ```TOTAL_AVAILABLE_PERMITS_UPDATER``` by the removed consumer's available permits when consumers' size > 1

- Added test case ```testTotalAvailablePermitsWhenRemoveConsumer()``` to verify:

  - Initial permit counting works correctly

  - Permit reduction happens properly when removing consumers


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
