### PR TITLE
[feat][client]Support shared resources in PulsarAdmin to reduce thread usage

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -25,7 +25,6 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.api.PulsarClientSharedResources;
-import org.apache.pulsar.client.api.PulsarClientSharedResourcesBuilder;
 
 /**
  * Builder class for a {@link PulsarAdmin} instance.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -400,13 +400,11 @@ public interface PulsarAdminBuilder {
      * Provide a set of shared client resources to be reused by this client.
      * <p>
      * Providing a shared resource instance allows PulsarClient instances to share resources
-     * (such as IO/event loops, timers, executors, DNS resolver/cache) with other PulsarClient
+     * (only support IO/event loops, timers, DNS resolver/cache) with other PulsarClient
      * instances, reducing memory footprint and thread usage when creating many clients in the same JVM.
      *
      * @param sharedResources the shared resources instance created with {@link PulsarClientSharedResources#builder()}
-     * @return the client builder instance
-     * @see PulsarClientSharedResources
-     * @see PulsarClientSharedResourcesBuilder
+     * @return the adminClient builder instance
      */
     PulsarAdminBuilder sharedResources(PulsarClientSharedResources sharedResources);
 

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+import org.apache.pulsar.client.api.PulsarClientSharedResources;
+import org.apache.pulsar.client.api.PulsarClientSharedResourcesBuilder;
 
 /**
  * Builder class for a {@link PulsarAdmin} instance.
@@ -393,4 +395,19 @@ public interface PulsarAdminBuilder {
      * @throws IllegalArgumentException if the length of description exceeds 64
      */
     PulsarAdminBuilder description(String description);
+
+    /**
+     * Provide a set of shared client resources to be reused by this client.
+     * <p>
+     * Providing a shared resource instance allows PulsarClient instances to share resources
+     * (such as IO/event loops, timers, executors, DNS resolver/cache) with other PulsarClient
+     * instances, reducing memory footprint and thread usage when creating many clients in the same JVM.
+     *
+     * @param sharedResources the shared resources instance created with {@link PulsarClientSharedResources#builder()}
+     * @return the client builder instance
+     * @see PulsarClientSharedResources
+     * @see PulsarClientSharedResourcesBuilder
+     */
+    PulsarAdminBuilder sharedResources(PulsarClientSharedResources sharedResources);
+
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -29,6 +29,8 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+import org.apache.pulsar.client.api.PulsarClientSharedResources;
+import org.apache.pulsar.client.impl.PulsarClientSharedResourcesImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 
@@ -39,10 +41,12 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
 
     private ClassLoader clientBuilderClassLoader = null;
     private boolean acceptGzipCompression = true;
+    private transient PulsarClientSharedResourcesImpl sharedResources;
 
     @Override
     public PulsarAdmin build() throws PulsarClientException {
-        return new PulsarAdminImpl(conf.getServiceUrl(), conf, clientBuilderClassLoader, acceptGzipCompression);
+        return new PulsarAdminImpl(conf.getServiceUrl(), conf,
+                clientBuilderClassLoader, acceptGzipCompression, sharedResources);
     }
 
     public PulsarAdminBuilderImpl() {
@@ -290,6 +294,12 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
             throw new IllegalArgumentException("description should be at most 64 characters");
         }
         this.conf.setDescription(description);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder sharedResources(PulsarClientSharedResources sharedResources) {
+        this.sharedResources = (PulsarClientSharedResourcesImpl) sharedResources;
         return this;
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.admin.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -56,6 +56,7 @@ import org.apache.pulsar.client.admin.internal.http.AsyncHttpConnectorProvider;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.PulsarClientSharedResourcesImpl;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.net.ServiceURI;
@@ -106,11 +107,12 @@ public class PulsarAdminImpl implements PulsarAdmin {
 
     public PulsarAdminImpl(String serviceUrl, ClientConfigurationData clientConfigData,
                            ClassLoader clientBuilderClassLoader) throws PulsarClientException {
-        this(serviceUrl, clientConfigData, clientBuilderClassLoader, true);
+        this(serviceUrl, clientConfigData, clientBuilderClassLoader, true, null);
     }
 
     public PulsarAdminImpl(String serviceUrl, ClientConfigurationData clientConfigData,
-                           ClassLoader clientBuilderClassLoader, boolean acceptGzipCompression)
+                           ClassLoader clientBuilderClassLoader, boolean acceptGzipCompression,
+                           PulsarClientSharedResourcesImpl sharedResources)
             throws PulsarClientException {
         checkArgument(StringUtils.isNotBlank(serviceUrl), "Service URL needs to be specified");
 
@@ -157,7 +159,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
                 Math.toIntExact(clientConfigData.getConnectionTimeoutMs()),
                 Math.toIntExact(clientConfigData.getReadTimeoutMs()),
                 Math.toIntExact(clientConfigData.getRequestTimeoutMs()),
-                clientConfigData.getAutoCertRefreshSeconds());
+                clientConfigData.getAutoCertRefreshSeconds(), sharedResources);
 
         long requestTimeoutMs = clientConfigData.getRequestTimeoutMs();
         this.clusters = new ClustersImpl(root, auth, requestTimeoutMs);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.admin.internal;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.Bookies;
 import org.apache.pulsar.client.admin.BrokerStats;
@@ -92,6 +94,7 @@ public class PulsarAdminImpl implements PulsarAdmin {
     private final ResourceQuotas resourceQuotas;
     private final ClientConfigurationData clientConfigData;
     private final Client client;
+    @Getter
     private final AsyncHttpConnector asyncHttpConnector;
     private final String serviceUrl;
     private final Lookup lookups;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorProvider.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.admin.internal.http;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Configuration;
+import org.apache.pulsar.client.impl.PulsarClientSharedResourcesImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
@@ -51,8 +52,8 @@ public class AsyncHttpConnectorProvider implements ConnectorProvider {
 
 
     public AsyncHttpConnector getConnector(int connectTimeoutMs, int readTimeoutMs, int requestTimeoutMs,
-            int autoCertRefreshTimeSeconds) {
+            int autoCertRefreshTimeSeconds, PulsarClientSharedResourcesImpl sharedResources) {
         return new AsyncHttpConnector(connectTimeoutMs, readTimeoutMs, requestTimeoutMs, autoCertRefreshTimeSeconds,
-                conf, acceptGzipCompression);
+                conf, acceptGzipCompression, sharedResources);
     }
 }

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImplTest.java
@@ -230,9 +230,8 @@ public class PulsarAdminBuilderImplTest {
                 pulsarAdminImpl2.getAsyncHttpConnector().getHttpClient().getConfig().getEventLoopGroup();
         Timer nettyTimer1 = pulsarAdminImpl1.getAsyncHttpConnector().getHttpClient().getConfig().getNettyTimer();
         Timer nettyTimer2 = pulsarAdminImpl2.getAsyncHttpConnector().getHttpClient().getConfig().getNettyTimer();
-        boolean b1 = eventLoopGroup1 == eventLoopGroup2;
-        boolean b2 = nettyTimer1 == nettyTimer2;
-        assertThat(b1 && b2).isTrue();
+        assertThat(eventLoopGroup1).isSameAs(eventLoopGroup2);
+        assertThat(nettyTimer1).isSameAs(nettyTimer2);
         sharedResources.close();
     }
 

--- a/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorTest.java
+++ b/pulsar-client-admin/src/test/java/org/apache/pulsar/client/admin/internal/http/AsyncHttpConnectorTest.java
@@ -176,7 +176,7 @@ public class AsyncHttpConnectorTest {
         };
         @Cleanup
         AsyncHttpConnector connector = new AsyncHttpConnector(5000, requestTimeout,
-                requestTimeout, 0, conf, false) {
+                requestTimeout, 0, conf, false, null) {
             @Override
             protected CompletableFuture<Response> oneShot(InetSocketAddress host, ClientRequest request) {
                 // delay the response to simulate a timeout
@@ -226,7 +226,7 @@ public class AsyncHttpConnectorTest {
 
         @Cleanup
         AsyncHttpConnector connector = new AsyncHttpConnector(5000, 5000,
-                5000, 0, conf, false);
+                5000, 0, conf, false, null);
 
         Request request = new RequestBuilder("GET")
                 .setUrl("http://localhost:" + server.port() + "/admin/v2/clusters")
@@ -272,7 +272,7 @@ public class AsyncHttpConnectorTest {
 
         @Cleanup
         AsyncHttpConnector connector = new AsyncHttpConnector(5000, 5000,
-                5000, 0, conf, false);
+                5000, 0, conf, false, null);
 
         Request request = new RequestBuilder("GET")
                 .setUrl("http://localhost:" + server.port() + "/path1")
@@ -298,7 +298,7 @@ public class AsyncHttpConnectorTest {
 
         @Cleanup
         AsyncHttpConnector connector = new AsyncHttpConnector(5000, 5000,
-                5000, 0, conf, false);
+                5000, 0, conf, false, null);
 
         Request request = new RequestBuilder("POST")
                 .setUrl("http://localhost:" + server.port() + "/path1")
@@ -322,7 +322,7 @@ public class AsyncHttpConnectorTest {
 
         @Cleanup
         AsyncHttpConnector connector = new AsyncHttpConnector(5000, 5000,
-                5000, 0, conf, false);
+                5000, 0, conf, false, null);
 
         Request request = new RequestBuilder("POST")
                 .setUrl("http://localhost:" + server.port() + "/concurrency-test")


### PR DESCRIPTION
Main Issue: https://github.com/apache/pulsar/issues/24796

### Motivation
When creating multiple PulsarAdmin clients in the same JVM, each client currently creates its own set of resources (event loops, timers, DNS resolvers). This leads to excessive thread consumption and memory usage when many admin clients are instantiated.

This change allows PulsarAdmin clients to share resources through the `PulsarClientSharedResources` mechanism, similar to what's already available for  PulsarClient.

### Modifications
1. Added `sharedResources(PulsarClientSharedResources)` method to `PulsarAdminBuilder` API
2. Modified `PulsarAdminBuilderImpl` to accept and propagate shared resources configuration
3. Updated `PulsarAdminImpl` constructor to pass shared resources to HTTP connector
4. Enhanced `AsyncHttpConnector` to utilize shared resources:
   - Event loop group for I/O operations
   - Netty timer for timeouts and scheduling
   - DNS resolver for name resolution
5. Added test to verify shared resources are properly reused across multiple admin clients.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [x] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
