### PR TITLE
[fix][test]fix flaky KeySharedSubscriptionBrokerCacheTest.testReplayQueueReadsGettingCached

### DIFF
--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockBookKeeper.java
@@ -260,7 +260,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
                             } else {
                                 return FutureUtils.value(new PulsarMockReadHandle(PulsarMockBookKeeper.this, ledgerId,
                                         lh.getLedgerMetadata(), lh.entries,
-                                        PulsarMockBookKeeper.this::getReadHandleInterceptor));
+                                        PulsarMockBookKeeper.this::getReadHandleInterceptor, lh.totalLengthCounter));
                             }
                         });
             }
@@ -303,6 +303,7 @@ public class PulsarMockBookKeeper extends BookKeeper {
         }
         for (PulsarMockLedgerHandle ledger : ledgers.values()) {
             ledger.entries.clear();
+            ledger.totalLengthCounter.set(0);
         }
         scheduler.shutdown();
         ledgers.clear();

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PulsarMockLedgerHandle extends LedgerHandle {
 
-    final List<LedgerEntryImpl> entries =  Collections.synchronizedList(new ArrayList<>());
+    final List<LedgerEntryImpl> entries = Collections.synchronizedList(new ArrayList<>());
     final PulsarMockBookKeeper bk;
     final long id;
     final DigestType digest;
@@ -163,8 +163,8 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
         }
 
         lastEntry = entries.size();
-        entries.add(LedgerEntryImpl.create(ledgerId, lastEntry, data.length, Unpooled.wrappedBuffer(data)));
         totalLengthCounter.addAndGet(data.length);
+        entries.add(LedgerEntryImpl.create(ledgerId, lastEntry, data.length, Unpooled.wrappedBuffer(data)));
         return lastEntry;
     }
 
@@ -196,9 +196,9 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
                     lastEntry = entries.size();
                     byte[] storedData = new byte[data.readableBytes()];
                     data.readBytes(storedData);
+                    totalLengthCounter.addAndGet(storedData.length);
                     entries.add(LedgerEntryImpl.create(ledgerId, lastEntry,
                                                        storedData.length, Unpooled.wrappedBuffer(storedData)));
-                    totalLengthCounter.addAndGet(storedData.length);
                     return FutureUtils.value(lastEntry);
                 }
 

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -19,7 +19,6 @@
 package org.apache.bookkeeper.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.security.GeneralSecurityException;
@@ -30,6 +29,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PulsarMockLedgerHandle extends LedgerHandle {
 
-    final ArrayList<LedgerEntryImpl> entries = Lists.newArrayList();
+    final List<LedgerEntryImpl> entries = new CopyOnWriteArrayList<>();
     final PulsarMockBookKeeper bk;
     final long id;
     final DigestType digest;

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -30,6 +30,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -63,6 +64,8 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
     @VisibleForTesting
     @Getter
     boolean fenced = false;
+    // Count for total length of the entries
+    final AtomicLong totalLengthCounter = new AtomicLong(0);
 
     public PulsarMockLedgerHandle(PulsarMockBookKeeper bk, long id,
                            DigestType digest, byte[] passwd) throws GeneralSecurityException {
@@ -73,7 +76,8 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
         this.digest = digest;
         this.passwd = Arrays.copyOf(passwd, passwd.length);
 
-        readHandle = new PulsarMockReadHandle(bk, id, getLedgerMetadata(), entries, bk::getReadHandleInterceptor);
+        readHandle = new PulsarMockReadHandle(bk, id, getLedgerMetadata(), entries,
+                bk::getReadHandleInterceptor, totalLengthCounter);
     }
 
     @Override
@@ -160,6 +164,7 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
 
         lastEntry = entries.size();
         entries.add(LedgerEntryImpl.create(ledgerId, lastEntry, data.length, Unpooled.wrappedBuffer(data)));
+        totalLengthCounter.addAndGet(data.length);
         return lastEntry;
     }
 
@@ -193,6 +198,7 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
                     data.readBytes(storedData);
                     entries.add(LedgerEntryImpl.create(ledgerId, lastEntry,
                                                        storedData.length, Unpooled.wrappedBuffer(storedData)));
+                    totalLengthCounter.addAndGet(storedData.length);
                     return FutureUtils.value(lastEntry);
                 }
 
@@ -231,12 +237,7 @@ public class PulsarMockLedgerHandle extends LedgerHandle {
 
     @Override
     public long getLength() {
-        long length = 0;
-        for (LedgerEntryImpl entry : entries) {
-            length += entry.getLength();
-        }
-
-        return length;
+        return totalLengthCounter.get();
     }
 
 

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockLedgerHandle.java
@@ -25,11 +25,11 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.Getter;
 import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
 import org.apache.bookkeeper.client.AsyncCallback.CloseCallback;
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PulsarMockLedgerHandle extends LedgerHandle {
 
-    final List<LedgerEntryImpl> entries = new CopyOnWriteArrayList<>();
+    final List<LedgerEntryImpl> entries =  Collections.synchronizedList(new ArrayList<>());
     final PulsarMockBookKeeper bk;
     final long id;
     final DigestType digest;

--- a/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
+++ b/testmocks/src/main/java/org/apache/bookkeeper/client/PulsarMockReadHandle.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.client;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
@@ -42,15 +43,18 @@ class PulsarMockReadHandle implements ReadHandle {
     private final LedgerMetadata metadata;
     private final List<LedgerEntryImpl> entries;
     private final Supplier<PulsarMockReadHandleInterceptor> readHandleInterceptorSupplier;
+    private final AtomicLong totalLengthCounter;
 
     PulsarMockReadHandle(PulsarMockBookKeeper bk, long ledgerId, LedgerMetadata metadata,
                          List<LedgerEntryImpl> entries,
-                         Supplier<PulsarMockReadHandleInterceptor> readHandleInterceptorSupplier) {
+                         Supplier<PulsarMockReadHandleInterceptor> readHandleInterceptorSupplier,
+                         AtomicLong totalLengthCounter) {
         this.bk = bk;
         this.ledgerId = ledgerId;
         this.metadata = metadata;
         this.entries = entries;
         this.readHandleInterceptorSupplier = readHandleInterceptorSupplier;
+        this.totalLengthCounter = totalLengthCounter;
     }
 
     @Override
@@ -99,12 +103,7 @@ class PulsarMockReadHandle implements ReadHandle {
 
     @Override
     public long getLength() {
-        long length = 0;
-        for (LedgerEntryImpl entry : entries) {
-            length += entry.getLength();
-        }
-
-        return length;
+        return totalLengthCounter.get();
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/24906

### Motivation
the test log is: https://gist.github.com/3pacccccc/7050810fa187f17046d826e7971c174a
From the error logs, we can see the exact failure:
```
java.util.ConcurrentModificationException: null
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013) ~[?:?]
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967) ~[?:?]
	at org.apache.bookkeeper.client.PulsarMockLedgerHandle.getLength(PulsarMockLedgerHandle.java:235) ~[testmocks-4.2.0-SNAPSHOT.jar:4.17.2]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.getEstimatedEntrySize(RangeEntryCacheImpl.java:503) ~[managed-ledger-4.2.0-SNAPSHOT.jar:4.2.0-SNAPSHOT]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.asyncReadEntriesByPosition(RangeEntryCacheImpl.java:310) ~[managed-ledger-4.2.0-SNAPSHOT.jar:4.2.0-SNAPSHOT]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.asyncReadEntry0(RangeEntryCacheImpl.java:286) ~[managed-ledger-4.2.0-SNAPSHOT.jar:4.2.0-SNAPSHOT]
	at org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl.asyncReadEntry(RangeEntryCacheImpl.java:268) ~[managed-ledger-4.2.0-SNAPSHOT.jar:4.2.0-SNAPSHOT]
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncReadEntry(ManagedLedgerImpl.java:2438) ~[managed-ledger-4.2.0-SNAPSHOT.jar:?]
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.internalReadFromLedger(ManagedLedgerImpl.java:2408) ~[managed-ledger-4.2.0-SNAPSHOT.jar:?]
	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.asyncReadEntries(ManagedLedgerImpl.java:2089) ~[managed-ledger-4.2.0-SNAPSHOT.jar:?]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncReadEntriesWithSkip(ManagedCursorImpl.java:918) ~[managed-ledger-4.2.0-SNAPSHOT.jar:?]
	at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncReadEntriesWithSkipOrWait(ManagedCursorImpl.java:1071) ~[managed-ledger-4.2.0-SNAPSHOT.jar:?]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.readMoreEntries(PersistentDispatcherMultipleConsumers.java:430) ~[classes/:?]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers.lambda$readMoreEntriesAsync$4(PersistentDispatcherMultipleConsumers.java:324) ~[classes/:?]

```
The root cause analysis shows:
1. **Thread safety issue**: The `entries` list in `PulsarMockLedgerHandle` was implemented as an `ArrayList`, which is not thread-safe
2. **Concurrent access**: Multiple threads were concurrently reading from and potentially modifying the entries list during test execution
3. **Cache invalidation**: When the `ConcurrentModificationException` occurred, it caused all caches to be removed, making all subsequent read operations fail[1]
4. **Complete read failure**: With the cache cleared and the test's interceptor configured to fail all BookKeeper reads (to enforce cache-only behavior), all subsequent read operations failed with `NonRecoverableLedgerException: Should not read from BK since cache should be used`[2]

[1]: https://github.com/apache/pulsar/blob/9737d038485e0c15f251dc334d6963fd0207953e/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/RangeEntryCacheImpl.java#L274
[2]: https://github.com/apache/pulsar/blob/b6cfecce5f3a1eecbf6f5df81cb835fbbfe35980/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionBrokerCacheTest.java#L198
### Modifications
Replace `ArrayList` with `CopyOnWriteArrayList` for the `entries` field in `PulsarMockLedgerHandle`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

