### PR TITLE
[improve][broker] Use atomic counter for ongoing transaction count

### DIFF
--- a/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
+++ b/pulsar-transaction/coordinator/src/main/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionMetadataStore.java
@@ -205,8 +205,9 @@ public class MLTransactionMetadataStore
                                     if (newStatus == TxnStatus.COMMITTED || newStatus == TxnStatus.ABORTED) {
                                         transactionLog.deletePosition(txnMetaMap
                                                 .get(transactionId).getRight()).thenAccept(v -> {
-                                                    txnMetaMap.remove(transactionId).getLeft();
-                                                    onGoingTxnCount.decrement();
+                                                    if (txnMetaMap.remove(transactionId) != null) {
+                                                        onGoingTxnCount.decrement();
+                                                    }
                                                 }
                                         );
                                     }
@@ -433,8 +434,9 @@ public class MLTransactionMetadataStore
                                     } else {
                                         abortedTransactionCount.increment();
                                     }
-                                    txnMetaMap.remove(txnID.getLeastSigBits());
-                                    onGoingTxnCount.decrement();
+                                    if (txnMetaMap.remove(txnID.getLeastSigBits()) != null) {
+                                        onGoingTxnCount.decrement();
+                                    }
                                     transactionLog.deletePosition(txnMetaListPair.getRight()).exceptionally(ex -> {
                                         log.warn("Failed to delete transaction log position "
                                                 + "at end transaction [{}]", txnID);

--- a/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
+++ b/pulsar-transaction/coordinator/src/test/java/org/apache/pulsar/transaction/coordinator/impl/MLTransactionLogImplTest.java
@@ -171,7 +171,7 @@ public class MLTransactionLogImplTest extends MockedBookKeeperTestCase {
                 new MLTransactionMetadataStore(transactionCoordinatorID,
                 mlTransactionLogForRecover, timeoutTracker, sequenceIdGenerator, Integer.MAX_VALUE);
         transactionMetadataStoreForRecover.init(recoverTracker).get(2000, TimeUnit.SECONDS);
-        Assert.assertEquals(transactionMetadataStoreForRecover.txnMetaMap.size(), expectedMapping.size());
+        Assert.assertEquals(transactionMetadataStoreForRecover.getOnGoingTxnCount().intValue(), expectedMapping.size());
         Iterator<Integer> txnIdSet = expectedMapping.keySet().iterator();
         while (txnIdSet.hasNext()){
             int txnId = txnIdSet.next();


### PR DESCRIPTION
### Motivation
Currently, `txnMetaMap.size()` is used to determine if a new transaction can be added and for metrics reporting. However, `txnMetaMap` is a `ConcurrentSkipListMap`, and calling `size()` is an O(n) operation, which can consume significant system resources, especially under high transaction loads.

This PR replaces the use of `txnMetaMap.size()` with a dedicated atomic counter (`onGoingTxnCount`) to track the number of ongoing transactions in constant time (O(1)). This improves performance and reduces overhead in transaction management.
### Modifications
1. Introduced a `LongAdder` field `onGoingTxnCount` in `MLTransactionMetadataStore` to maintain the ongoing transaction count.
2. Updated all relevant methods to increment/decrement the counter when transactions are added or removed.
3. Refactored test cases to use `getOnGoingTxnCount()` instead of accessing the map via reflection, improving test clarity and maintainability.
4. Ensured metrics and coordinator stats now use the atomic counter instead of `txnMetaMap.size()`.
### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: 
